### PR TITLE
Look for more patterns to enable pgp verify button

### DIFF
--- a/views/auth/pgp.php
+++ b/views/auth/pgp.php
@@ -27,7 +27,7 @@ $(function(){
   $("#submit-challenge").attr("disabled", "disabled");
 
   var enableSubmit = function(){
-    if($("#signed").val().indexOf("BEGIN PGP SIGNATURE") !== -1) {
+    if(/BEGIN PGP (SIGNED )?MESSAGE/.test($("#signed").val())) {
       $("#submit-challenge").removeAttr("disabled");
     }
   };


### PR DESCRIPTION
The PGP login can use the output of either `gpg --sign --armor` or `gpg --clear-sign --armor`. These use the ascii armor headers "BEGIN PGP MESSAGE" and "BEGIN PGP SIGNED MESSAGE" respectively. This enables the button for either of them, instead of just the latter. It no longer looks for "BEGIN PGP SIGNATURE" because this also appears in the output of `gpg --detach-sign --armor`, which does not work.