### PR TITLE
Healthcheck endpoint

### DIFF
--- a/app/Healthcheck.php
+++ b/app/Healthcheck.php
@@ -1,0 +1,48 @@
+<?php
+namespace App;
+
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\ServerRequestInterface;
+use Config;
+use ORM;
+
+class Healthcheck {
+  const ERROR = 'ERROR';
+  const OK = 'OK';
+  const REDIS_SUCCESSFUL_PING = 'PONG';
+
+  public function index(ServerRequestInterface $request, ResponseInterface $response) {
+    $userlog = make_logger('healthcheck');
+
+    $services = [
+      'mysql' => self::ERROR,
+      'redis' => self::ERROR,
+    ];
+
+    // Redis
+    try {
+      if(redis()->ping() == self::REDIS_SUCCESSFUL_PING) {
+        $services['redis'] = self::OK;
+      }
+    } catch(\Predis\Connection\ConnectionException $e) {
+      $userlog->info(
+        'Redis connection healthcheck failure'
+      );
+    }
+
+    // MySQL
+    try {
+      ORM::raw_execute('SELECT version();');
+      $services['mysql'] = self::OK;
+    } catch(\Exception $e) {
+      $userlog->info(
+        'MySQL connection healthcheck failure'
+      );
+    }
+
+    // Always
+    $response->getBody()->write(json_encode($services));
+    return $response;
+  }
+}
+

--- a/lib/helpers.php
+++ b/lib/helpers.php
@@ -5,6 +5,8 @@ use Psr\Http\Message\UriInterface;
 use Monolog\Logger;
 use Monolog\Handler\StreamHandler;
 
+const LOCAL_FALLBACK_REDIS = 'tcp://127.0.0.1:6379';
+
 date_default_timezone_set('UTC');
 
 if(getenv('ENV')) {
@@ -61,10 +63,14 @@ function random_user_code() {
   return $code;
 }
 
+function get_redis_url() {
+  return $redisURL = getenv('REDIS_URL') ?? LOCAL_FALLBACK_REDIS;
+}
 function redis() {
   static $client = false;
-  if(!$client)
-    $client = new Predis\Client('tcp://127.0.0.1:6379');
+  if(!$client) {
+    $client = new Predis\Client(get_redis_url());
+  }
   return $client;
 }
 

--- a/public/index.php
+++ b/public/index.php
@@ -24,7 +24,7 @@ initdb();
 $route = new League\Route\RouteCollection($container);
 
 $route->map('GET', '/', 'App\\Controller::index');
-
+$route->map('GET', '/health', 'App\\Healthcheck::index');
 $route->map('GET', '/api', 'App\\Controller::api_docs');
 $route->map('GET', '/setup', 'App\\Controller::setup_docs');
 $route->map('GET', '/faq', 'App\\Controller::faq');


### PR DESCRIPTION
Again breaking down the heroku button PR. This is the healthcheck endpoint which reports if MySQL or Redis are down. It does not surface any error specifics frontend or backend ~, but does add logs so that the deployment admin can get clues about what is unhealthy / healthy about an indielogin.com deploy~

## Local Docker health endpoint

![Screenshot from 2019-08-17 22-34-59](https://user-images.githubusercontent.com/2605791/63217513-54201580-c13f-11e9-8e15-92a42e0d3162.png)

## Heroku deploy healthcheck

![Screenshot from 2019-08-17 22-31-00](https://user-images.githubusercontent.com/2605791/63217527-8d588580-c13f-11e9-9ff1-dc5714019b93.png)
