### PR TITLE
12-factor QoL : ENV -> Config fallback

### DIFF
--- a/app/Authenticate.php
+++ b/app/Authenticate.php
@@ -104,7 +104,7 @@ class Authenticate {
       $devlog->info('Bad auth request', ['errors' => $errors, 'params' => $params]);
 
       $response->getBody()->write(view('auth/dev-error', [
-        'title' => Config::$name.' Error',
+        'title' => get_setting('name').' Error',
         'errors' => $errors
       ]));
       return $response;
@@ -122,7 +122,7 @@ class Authenticate {
 
       // If the developer isn't expecting a particular user, use the session user if present
       $response->getBody()->write(view('auth/login-form', [
-        'title' => 'Sign In using '.Config::$name,
+        'title' => 'Sign In using '.get_setting('name'),
         'me' => $_SESSION['me'] ?? '',
         'client_id' => $client_id,
         'redirect_uri' => $redirect_uri,
@@ -149,7 +149,7 @@ class Authenticate {
         $_SESSION['me_entered'] = $_SESSION['me'];
 
         $response->getBody()->write(view('auth/prompt', [
-          'title' => 'Sign In using '.Config::$name,
+          'title' => 'Sign In using '.get_setting('name'),
           'me' => $_SESSION['me'],
           'code' => $code,
           'client_id' => $client_id,

--- a/app/Controller.php
+++ b/app/Controller.php
@@ -10,7 +10,7 @@ class Controller {
 
   public function index(ServerRequestInterface $request, ResponseInterface $response) {
     $response->getBody()->write(view('index', [
-      'title' => Config::$name,
+      'title' => get_setting('name'),
     ]));
     return $response;
   }
@@ -38,7 +38,7 @@ class Controller {
     $log->save();
 
     $response->getBody()->write(view('demo', [
-      'title' => Config::$name,
+      'title' => get_setting('name'),
       'me' => $login['me'],
     ]));
     return $response;
@@ -46,21 +46,21 @@ class Controller {
 
   public function api_docs(ServerRequestInterface $request, ResponseInterface $response) {
     $response->getBody()->write(view('docs/api', [
-      'title' => Config::$name.' API Docs',
+      'title' => get_setting('name').' API Docs',
     ]));
     return $response;
   }
 
   public function setup_docs(ServerRequestInterface $request, ResponseInterface $response) {
     $response->getBody()->write(view('docs/setup', [
-      'title' => 'How to Start Using '.Config::$name,
+      'title' => 'How to Start Using '.get_setting('name'),
     ]));
     return $response;
   }
 
   public function faq(ServerRequestInterface $request, ResponseInterface $response) {
     $response->getBody()->write(view('docs/faq', [
-      'title' => Config::$name.' FAQ',
+      'title' => get_setting('name').' FAQ',
     ]));
     return $response;
   }

--- a/app/Provider/Email.php
+++ b/app/Provider/Email.php
@@ -53,16 +53,16 @@ trait Email {
 
     redis()->setex('indielogin:email:usercode:'.$params['code'], EMAIL_TIMEOUT, $usercode);
 
-    $login_url = Config::$base.'auth/verify_email_code?'.http_build_query([
+    $login_url = get_setting('base').'auth/verify_email_code?'.http_build_query([
       'code' => $params['code'],
       'usercode' => $usercode,
     ]);
 
-    $mg = new Mailgun(Config::$mailgun['key']);
-    $result = $mg->sendMessage(Config::$mailgun['domain'], [
-      'from'     => Config::$mailgun['from'],
+    $mg = new Mailgun(get_setting('mailgun', 'key'));
+    $result = $mg->sendMessage(get_setting('mailgun', 'domain'), [
+      'from'     => get_setting('mailgun', 'from'),
       'to'       => $login['email'],
-      'subject'  => 'Your '.Config::$name.' Code: '.$usercode,
+      'subject'  => 'Your '.get_setting('name').' Code: '.$usercode,
       'text'     => "Enter the code below to sign in: \n\n$usercode\n"
     ]);
 

--- a/app/Provider/GitHub.php
+++ b/app/Provider/GitHub.php
@@ -13,8 +13,8 @@ trait GitHub {
     $state = generate_state();
 
     $params = [
-      'client_id' => Config::$githubClientID,
-      'redirect_uri' => Config::$base.'redirect/github',
+      'client_id' => get_setting('githubClientID'),
+      'redirect_uri' => get_setting('base').'redirect/github',
       'state' => $state,
       'allow_signup' => 'false',
     ];
@@ -43,10 +43,10 @@ trait GitHub {
     unset($_SESSION['state']);
 
     $params = [
-      'client_id' => Config::$githubClientID,
-      'client_secret' => Config::$githubClientSecret,
+      'client_id' => get_setting('githubClientID'),
+      'client_secret' => get_setting('githubClientSecret'),
       'code' => $query['code'],
-      'redirect_uri' => Config::$base.'redirect/github',
+      'redirect_uri' => get_setting('base').'redirect/github',
     ];
 
     $http = http_client();

--- a/app/Provider/IndieAuth.php
+++ b/app/Provider/IndieAuth.php
@@ -12,7 +12,7 @@ trait IndieAuth {
 
     // Encode this request's me/redirect_uri/state in the state parameter to avoid a session?
     $state = generate_state();
-    $authorize = \IndieAuth\Client::buildAuthorizationURL($details['authorization_endpoint'], $login_request['me'], Config::$base.'redirect/indieauth', Config::$base, $state, '');
+    $authorize = \IndieAuth\Client::buildAuthorizationURL($details['authorization_endpoint'], $login_request['me'], get_setting('base').'redirect/indieauth', get_setting('base'), $state, '');
 
     $userlog->info('Beginning IndieAuth login', ['provider' => $details, 'login' => $login_request]);
 
@@ -54,8 +54,8 @@ trait IndieAuth {
 
     $params = [
       'code' => $query['code'],
-      'client_id' => Config::$base,
-      'redirect_uri' => Config::$base.'redirect/indieauth',
+      'client_id' => get_setting('base'),
+      'redirect_uri' => get_setting('base').'redirect/indieauth',
     ];
 
     $userlog->info('Verifying the authorization code with the IndieAuth server', [

--- a/app/Provider/PGP.php
+++ b/app/Provider/PGP.php
@@ -57,7 +57,7 @@ trait PGP {
 
     $keytext = $login['keytext'];
 
-    $ch = curl_init(Config::$pgpVerificationAPI.'/verify');
+    $ch = curl_init(get_setting('pgpVerificationAPI').'/verify');
     curl_setopt($ch, CURLOPT_RETURNTRANSFER, true);
     curl_setopt($ch, CURLOPT_POSTFIELDS, http_build_query([
       'key' => $keytext,

--- a/app/Provider/Twitter.php
+++ b/app/Provider/Twitter.php
@@ -14,10 +14,10 @@ trait Twitter {
     $_SESSION['twitter_expected_user'] = $details['username'];
     $_SESSION['login_request']['profile'] = 'https://twitter.com/'.$details['username'];
 
-    $twitter = new TwitterOAuth(Config::$twitterClientID, Config::$twitterClientSecret);
+    $twitter = new TwitterOAuth(get_setting('twitterClientID'), get_setting('twitterClientSecret'));
 
     $request_token = $twitter->oauth('oauth/request_token', [
-      'oauth_callback' => Config::$base . 'redirect/twitter'
+      'oauth_callback' => get_setting('base') . 'redirect/twitter'
     ]);
     $_SESSION['twitter_request_token'] = $request_token;
     $twitter_login_url = $twitter->url('oauth/authenticate', ['oauth_token' => $request_token['oauth_token']]);
@@ -38,7 +38,7 @@ trait Twitter {
       return $response->withHeader('Location', '/')->withStatus(302);
     }
 
-    $twitter = new TwitterOAuth(Config::$twitterClientID, Config::$twitterClientSecret,
+    $twitter = new TwitterOAuth(get_setting('twitterClientID'), get_setting('twitterClientSecret'),
       $_SESSION['twitter_request_token']['oauth_token'], $_SESSION['twitter_request_token']['oauth_token_secret']);
     $credentials = $twitter->oauth('oauth/access_token', ['oauth_verifier' => $query['oauth_verifier']]);
 
@@ -58,7 +58,7 @@ trait Twitter {
       return $this->_userError($response, 'You logged in to Twitter as <b>@'.$twitter_user.'</b> but your website links to <b>@'.$_SESSION['twitter_expected_user'].'</b>');
     }
 
-    $twitter = new TwitterOAuth(Config::$twitterClientID, Config::$twitterClientSecret,
+    $twitter = new TwitterOAuth(get_setting('twitterClientID'), get_setting('twitterClientSecret'),
       $credentials['oauth_token'], $credentials['oauth_token_secret']);
 
     // Fetch the full profile to look for the link to their website

--- a/views/docs/api.php
+++ b/views/docs/api.php
@@ -2,15 +2,15 @@
 
 <div class="container container-narrow api-docs">
 
-  <h1><?= Config::$name ?></h1>
+  <h1><?= get_setting('name') ?></h1>
 
-  <p>If you are building a website and need to sign people in, you can use <?= Config::$name ?> to handle all the complicated parts.</p>
+  <p>If you are building a website and need to sign people in, you can use <?= get_setting('name') ?> to handle all the complicated parts.</p>
 
   <p>Users will identify themselves with their website, and can authenticate using one of the <a href="/setup">supported authentication providers</a> such as Twitter, GitHub, or email. The user ID returned to you will be their website, ensuring that you don't end up creating multiple accounts depending on how the user authenticates.</p>
 
   <h2>1. Create a Web Sign-In form</h2>
 
-  <?php $base = Config::$base; ?>
+  <? $base = get_setting('base'); ?>
   <pre><code><?= e(<<<EOT
 <form action="${base}auth" method="get">
   <label for="url">Web Address:</label>
@@ -26,7 +26,7 @@ EOT
   <h3>Parameters</h3>
 
   <ul>
-    <li><b>action</b>: Set the action of the form to this service (<code><?= Config::$base ?>auth</code>) or <a href="https://github.com/aaronpk/IndieLogin.com">download the source</a> and run your own server.</li>
+    <li><b>action</b>: Set the action of the form to this service (<code><?= get_setting('base') ?>auth</code>) or <a href="https://github.com/aaronpk/IndieLogin.com">download the source</a> and run your own server.</li>
     <li><b>me</b>: (optional) The "me" parameter is the URL that the user enters. If you leave this out, then this website will prompt the user to enter their URL.</li>
     <li><b>client_id</b>: Set the client_id in a hidden field to let this site know the home page of the application the user is signing in to.</li>
     <li><b>redirect_uri</b>: Set the redirect_uri in a hidden field to let this site know where to redirect back to after authentication is complete. It must be on the same domain as the client_id.</li>
@@ -37,7 +37,7 @@ EOT
 
   <h2>2. The user logs in with their domain</h2>
 
-  <p>After the user enters their domain in the sign-in form and submits, <?= Config::$name ?> will scan their website looking for <code>rel="me"</code> links from providers it knows about (see <a href="/setup">Supported Providers</a>).</p>
+  <p>After the user enters their domain in the sign-in form and submits, <?= get_setting('name') ?> will scan their website looking for <code>rel="me"</code> links from providers it knows about (see <a href="/setup">Supported Providers</a>).</p>
 
   <p>They will authenticate using one of the supported providers, such as authenticating with their own IndieAuth server, logging in on GitHub, or verifying a temporary code sent to their email address.</p>
 
@@ -48,11 +48,11 @@ EOT
   <p>If everything is successful, the user will be redirected back to the <code>redirect_uri</code> you specified in the form. You'll see two parameters in the query string, <code>state</code> and <code>code</code>. Check that the state matches the value you set originally before continuing.</p>
 
 
-  <h2>4. Verify the authorization code with <?= Config::$name ?></h2>
+  <h2>4. Verify the authorization code with <?= get_setting('name') ?></h2>
 
-  <p>At this point you need to verify the code which will also return the website of the authenticated user. Make a POST request to <code><?= Config::$base ?>auth</code> with the code, client_id and redirect_uri, and you will get back the full website of the authenticated user.</p>
+  <p>At this point you need to verify the code which will also return the website of the authenticated user. Make a POST request to <code><?= get_setting('base') ?>auth</code> with the code, client_id and redirect_uri, and you will get back the full website of the authenticated user.</p>
 
-  <p><pre>POST <?= Config::$base?>auth HTTP/1.1
+  <p><pre>POST <?= get_setting('base')?>auth HTTP/1.1
 Content-Type: application/x-www-form-urlencoded;charset=UTF-8
 Accept: application/json
 

--- a/views/docs/faq.php
+++ b/views/docs/faq.php
@@ -7,37 +7,37 @@ $this->layout('layout', ['title' => $title]);
 <div class="container container-narrow api-docs">
 <?php ob_start() ?>
 
-# <?= Config::$name ?> FAQ
+# <?= get_setting('name') ?> FAQ
 
 
-### Why does <?= Config::$name ?> ask for permission to read my tweets? {#twitter-permissions}
+### Why does <?= get_setting('name') ?> ask for permission to read my tweets? {#twitter-permissions}
 
-If you choose to authenticate with Twitter, <?= Config::$name ?> uses the Twitter API to verify your account. The least amount of permissions this site can request from the Twitter API is to read your tweets. This site does not actually read your tweets or access your Twitter account in any way other than to verify your Twitter username after you authenticate. Your Twitter tokens are never stored by this site or provided to the site you're logging in to.
+If you choose to authenticate with Twitter, <?= get_setting('name') ?> uses the Twitter API to verify your account. The least amount of permissions this site can request from the Twitter API is to read your tweets. This site does not actually read your tweets or access your Twitter account in any way other than to verify your Twitter username after you authenticate. Your Twitter tokens are never stored by this site or provided to the site you're logging in to.
 
 If you are uncomfortable with the permissions requested, you can choose to authenticate using a <a href="/setup">different provider</a> such as your IndieAuth server, GitHub, email, or PGP key.
 
 
-### Why does <?= Config::$name ?> ask for permission to read my public data in my GitHub account? {#github-permissions}
+### Why does <?= get_setting('name') ?> ask for permission to read my public data in my GitHub account? {#github-permissions}
 
-If you choose to authenticate with GitHub, <?= Config::$name ?> uses the GitHub API to verify your account. The least amount of permissions this site can request from GitHub is accessing your public data. This site does not actually access your GitHub account other than to verify your username. Your GitHub token is never stored by this site or provided to the site you're logging in to.
+If you choose to authenticate with GitHub, <?= get_setting('name') ?> uses the GitHub API to verify your account. The least amount of permissions this site can request from GitHub is accessing your public data. This site does not actually access your GitHub account other than to verify your username. Your GitHub token is never stored by this site or provided to the site you're logging in to.
 
 If you are uncomfortable with the permissions requested, you can choose to authenticate using a <a href="/setup">different provider</a> such as your IndieAuth server, Twitter, email, or PGP key.
 
 
-### What is the difference between <?= Config::$name ?> and IndieAuth? {#difference-indieauth}
+### What is the difference between <?= get_setting('name') ?> and IndieAuth? {#difference-indieauth}
 
-<?= Config::$name ?> is a service for developers who want to offload logging in users to an external service, and implements web sign-in by consuming IndieAuth, other OAuth APIs, as well as email and PGP verification.
+<?= get_setting('name') ?> is a service for developers who want to offload logging in users to an external service, and implements web sign-in by consuming IndieAuth, other OAuth APIs, as well as email and PGP verification.
 
 IndieAuth is a protocol that lets your website be its own identity while supporting OAuth 2.0.
 
-If you'd like to let people log in to your website or application, you can implement web sign-in yourself, or you can delegate that to <?= Config::$name ?>.
+If you'd like to let people log in to your website or application, you can implement web sign-in yourself, or you can delegate that to <?= get_setting('name') ?>.
 
 If you'd like to add IndieAuth support to your website, visit <a href="https://indieweb.org/IndieAuth">indieweb.org/IndieAuth</a> for links to services, plugins, and other documentation you can use to get started.
 
 
-### Can I run my own instance of <?= Config::$name ?>? {#can-i-run-my-own-instance}
+### Can I run my own instance of <?= get_setting('name') ?>? {#can-i-run-my-own-instance}
 
-Absolutely yes! In fact, if you're developing an application, you're absolutely encouraged to implement web sign-in yourself, or run a copy of this code on your own. You can find the source code to <?= Config::$name ?> <a href="https://github.com/aaronpk/IndieLogin.com">on GitHub</a>.
+Absolutely yes! In fact, if you're developing an application, you're absolutely encouraged to implement web sign-in yourself, or run a copy of this code on your own. You can find the source code to <?= get_setting('name') ?> <a href="https://github.com/aaronpk/IndieLogin.com">on GitHub</a>.
 
 
 <?php

--- a/views/docs/privacy.php
+++ b/views/docs/privacy.php
@@ -11,7 +11,7 @@ $this->layout('layout', ['title' => $title]);
 
 ### Logs
 
-<?= Config::$name ?> keeps logs of attempted and successful authentications. Properties of each log record are:
+<?= get_setting('name') ?> keeps logs of attempted and successful authentications. Properties of each log record are:
 
 * the date of the authentication attempt
 * the application identifier
@@ -30,7 +30,7 @@ Things that are not stored or logged in any way:
 
 ### Data Provided to Developers
 
-Since <?= Config::$name ?> is a service for developers wishing to easily implement logging in to apps, this service provides some information to the developers of the applications users log in to.
+Since <?= get_setting('name') ?> is a service for developers wishing to easily implement logging in to apps, this service provides some information to the developers of the applications users log in to.
 
 After a successful authentication, this website returns the fully resolved profile URL of the user who authenticated to the developer.
 

--- a/views/docs/setup.php
+++ b/views/docs/setup.php
@@ -2,10 +2,10 @@
 
 <div class="container container-narrow setup h-entry">
 
-  <h1 class="p-name">How to Set Up Your Website for <?= Config::$name ?></h1>
+  <h1 class="p-name">How to Set Up Your Website for <?= get_setting('name') ?></h1>
 
   <div class="e-content">
-    <p>You've likely ended up here because a website you're trying to sign in to uses <?= Config::$name ?> to handle logging users in.</p>
+    <p>You've likely ended up here because a website you're trying to sign in to uses <?= get_setting('name') ?> to handle logging users in.</p>
 
     <p>Instead of making a new account here, we'll take advantage of some accounts you may already have in order to authenticate you. You can always choose the services you use to log in, and the site you're logging in to won't have access to them.</p>
   </div>
@@ -101,12 +101,12 @@
   <section id="choosing-auth-providers" class="h-entry">
     <h3 class="p-name">Explicitly Choosing Auth Providers</h3>
 
-    <p>If you don't want <?= Config::$name ?> to consider <i>all</i> your <code>rel="me"</code> links as possible authentication options, you can choose which ones specifically by using <code>rel="me authn"</code> instead. This allows you to, for example, only use providers that support two-factor authorization, while still linking to your existing profiles using <code>rel="me"</code>.</p>
+    <p>If you don't want <?= get_setting('name') ?> to consider <i>all</i> your <code>rel="me"</code> links as possible authentication options, you can choose which ones specifically by using <code>rel="me authn"</code> instead. This allows you to, for example, only use providers that support two-factor authorization, while still linking to your existing profiles using <code>rel="me"</code>.</p>
 
     <p><pre><?= e('<a href="https://twitter.com/aaronpk" rel="me">twitter.com/aaronpk</a>
 <a href="https://github.com/aaronpk" rel="me authn">github.com/aaronpk</a>') ?></pre></p>
 
-    <p>If <i>any</i> of your <code>rel="me"</code> links also include <code>authn</code> in the list of rels, then <?= Config::$name ?> will <i>only</i> use the links with <code>authn</code>, and will no longer consider your plain <code>rel="me"</code> links as authentication options.</p>
+    <p>If <i>any</i> of your <code>rel="me"</code> links also include <code>authn</code> in the list of rels, then <?= get_setting('name') ?> will <i>only</i> use the links with <code>authn</code>, and will no longer consider your plain <code>rel="me"</code> links as authentication options.</p>
   </section>
 
 

--- a/views/index.php
+++ b/views/index.php
@@ -3,7 +3,7 @@
 <div class="position-relative overflow-hidden p-3 p-md-5 m-md-3 text-center bg-light">
   <div class="col-md-5 p-lg-5 mx-auto my-5">
 
-    <h1 class="display-4 font-weight-normal"><?= Config::$name ?></h1>
+    <h1 class="display-4 font-weight-normal"><?= get_setting('name') ?></h1>
 
     <p class="lead font-weight-normal">Sign in with your domain name.</p>
 
@@ -15,8 +15,8 @@
           <input type="url" placeholder="example.com" name="me" class="form-control">
         </div>
 
-        <input type="hidden" name="client_id" value="<?= Config::$base ?>">
-        <input type="hidden" name="redirect_uri" value="<?= Config::$base ?>demo">
+        <input type="hidden" name="client_id" value="<?= get_setting('base') ?>">
+        <input type="hidden" name="redirect_uri" value="<?= get_setting('base') ?>demo">
         <input type="hidden" name="state" value="<?= generate_state() ?>">
 
         <button class="btn btn-outline-secondary">Sign In</button>
@@ -33,12 +33,12 @@
 
   <div class="row featurette">
     <div class="col-md-7">
-      <h2 class="featurette-heading">What is <span class="text-muted"><?= Config::$name ?>?</span></h2>
-      <p class="lead"><?= Config::$name ?> makes it easy to add web sign-in to your applications.</p>
+      <h2 class="featurette-heading">What is <span class="text-muted"><?= get_setting('name') ?>?</span></h2>
+      <p class="lead"><?= get_setting('name') ?> makes it easy to add web sign-in to your applications.</p>
 
       <p>If you'd like to let your users <b>log in with their own domain name</b> as their identity, you can use IndieLogin.com to handle the details of that for you.</p>
 
-      <p><?= Config::$name ?> supports <a href="https://indieauth.net/">IndieAuth</a>, so users with supported websites will be able to sign in using their own website's login. Otherwise, <?= Config::$name?> will check for links to Twitter, GitHub, an email address or PGP key, and will ask the user to authenticate that way. Regardless of how the user authenticates, the identity provided to the application will always be the user's primary website.</p>
+      <p><?= get_setting('name') ?> supports <a href="https://indieauth.net/">IndieAuth</a>, so users with supported websites will be able to sign in using their own website's login. Otherwise, <?= get_setting('name')?> will check for links to Twitter, GitHub, an email address or PGP key, and will ask the user to authenticate that way. Regardless of how the user authenticates, the identity provided to the application will always be the user's primary website.</p>
     </div>
     <div class="col-md-5">
       <img class="featurette-image img-fluid mx-auto" src="/images/web-signin-splash.jpg" alt="Web Sign-In Prompt">


### PR DESCRIPTION
Another PR from the Heroku button.

This one is modified to avoid the need for a redundant config file in environments which are more geared towards receiving configuration via environment such as Heroku, Docker, CloudFoundry.

Because of the absence of a test suite runner right now, I've included a PHP online sandbox. Because it blacklists the class_exists method I've omitted that ternary, and I also directly set $_ENV to simulate environment input (mutable state FTW I guess)

http://sandbox.onlinephpfunctions.com/code/5487577392110c118827c529d8f0e183b31b7d93

Both the Docker PR's #34 & #43 would benefit from these works