### PR TITLE
Re-runnable schema.sql

### DIFF
--- a/schema/schema.sql
+++ b/schema/schema.sql
@@ -1,4 +1,4 @@
-CREATE TABLE `clients` (
+CREATE TABLE IF NOT EXISTS `clients` (
   `id` int(11) unsigned NOT NULL AUTO_INCREMENT,
   `client_id` varchar(512) DEFAULT NULL,
   `user_url` varchar(512) DEFAULT NULL,
@@ -7,7 +7,7 @@ CREATE TABLE `clients` (
   KEY `client_id` (`client_id`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8;
 
-CREATE TABLE `redirect_uris` (
+CREATE TABLE IF NOT EXISTS `redirect_uris` (
   `id` int(11) unsigned NOT NULL AUTO_INCREMENT,
   `client_id` int(11) DEFAULT NULL,
   `redirect_uri` varchar(512) DEFAULT NULL,
@@ -15,7 +15,7 @@ CREATE TABLE `redirect_uris` (
   KEY `client_id` (`client_id`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8;
 
-CREATE TABLE `logins` (
+CREATE TABLE IF NOT EXISTS `logins` (
   `id` int(11) unsigned NOT NULL AUTO_INCREMENT,
   `date` datetime DEFAULT NULL,
   `client_id` varchar(512) DEFAULT NULL,


### PR DESCRIPTION
fixup schema.sql so I can run many times

This was originally part of the heroku deploy PR. DB migrations etc were never handled as part of that PR, I simply ran the script as an ad-hoc task in local docker and inferred (because I know you can) that a heroku admin would do the same using appropriate vendor tooling (Heroku has many vendors).

## Considerations

This will literally skip creation of resources, not keep them in sync if they are out of date. This is not how migrations tend to work, so this is considered more of a bootstrap script. modification to ensure subsequent runs do not show errors and cause panic.