### PR TITLE
Convert non-output short-tags to full tags

### DIFF
--- a/views/auth/email-enter-code.php
+++ b/views/auth/email-enter-code.php
@@ -2,9 +2,9 @@
 
 <div class="container container-narrow">
 
-  <? if($error ?? false): ?>
+  <?php if($error ?? false): ?>
     <div class="alert alert-danger"><?= $error ?></div>
-  <? endif ?>
+  <?php endif ?>
 
   <div id="usercode-prompt">
 

--- a/views/auth/email-error.php
+++ b/views/auth/email-error.php
@@ -1,15 +1,15 @@
-<? $this->layout('layout', ['title' => $title]) ?>
+<?php $this->layout('layout', ['title' => $title]) ?>
 
 <div class="container container-narrow">
 
-  <? if($error): ?>
+  <?php if($error): ?>
     <div class="alert alert-warning"><?= $error ?></div>
-  <? endif ?>
+  <?php endif ?>
 
   <p>Please go back to the application and try again.</p>
 
-  <? if(isset($client_id) && \p3k\url\is_url($client_id)): ?>
+  <?php if(isset($client_id) && \p3k\url\is_url($client_id)): ?>
     <p><a href="<?= e($client_id) ?>"><?= e(\p3k\url\display_url($client_id)) ?></a></p>
-  <? endif ?>
+  <?php endif ?>
 
 </div>

--- a/views/auth/pgp-error.php
+++ b/views/auth/pgp-error.php
@@ -1,15 +1,15 @@
-<? $this->layout('layout', ['title' => $title]) ?>
+<?php $this->layout('layout', ['title' => $title]) ?>
 
 <div class="container container-narrow">
 
-  <? if($error): ?>
+  <?php if($error): ?>
     <div class="alert alert-warning"><?= $error ?></div>
-  <? endif ?>
+  <?php endif ?>
 
   <p>Please go back to the application and try again.</p>
 
-  <? if(isset($client_id) && \p3k\url\is_url($client_id)): ?>
+  <?php if(isset($client_id) && \p3k\url\is_url($client_id)): ?>
     <p><a href="<?= e($client_id) ?>"><?= e(\p3k\url\display_url($client_id)) ?></a></p>
-  <? endif ?>
+  <?php endif ?>
 
 </div>

--- a/views/auth/user-error.php
+++ b/views/auth/user-error.php
@@ -1,27 +1,27 @@
-<? $this->layout('layout', ['title' => $title]) ?>
+<?php $this->layout('layout', ['title' => $title]) ?>
 
 <div class="container container-narrow">
 
-  <? if($error): ?>
+  <?php if($error): ?>
     <div class="alert alert-warning"><?= $error ?></div>
-  <? endif ?>
+  <?php endif ?>
 
-  <? if(isset($opts['found'])): ?>
+  <?php if(isset($opts['found'])): ?>
     <p>The following links were found on your website, but are not supported authentication options.</p>
     <ul>
-    <? foreach($opts['found'] as $f): ?>
+    <?php foreach($opts['found'] as $f): ?>
       <li><a href="<?= e($f) ?>"><?= e($f) ?></a></li>
-    <? endforeach ?>
+    <?php endforeach ?>
     </ul>
-  <? endif ?>
+  <?php endif ?>
 
-  <? if(isset($opts['me'])): ?>
+  <?php if(isset($opts['me'])): ?>
     <p>We got an error trying to connect to <code><?= e($opts['me']) ?></code></p>
-  <? endif ?>
+  <?php endif ?>
 
-  <? if(isset($opts['response'])): ?>
+  <?php if(isset($opts['response'])): ?>
     <pre><?= e($opts['response']) ?></pre>
-  <? endif ?>
+  <?php endif ?>
 
   <p>View the <a href="/setup">setup instructions</a> for more information.</p>
 

--- a/views/docs/api.php
+++ b/views/docs/api.php
@@ -10,7 +10,7 @@
 
   <h2>1. Create a Web Sign-In form</h2>
 
-  <? $base = Config::$base; ?>
+  <?php $base = Config::$base; ?>
   <pre><code><?= e(<<<EOT
 <form action="${base}auth" method="get">
   <label for="url">Web Address:</label>

--- a/views/layout.php
+++ b/views/layout.php
@@ -51,7 +51,7 @@
 
   <?= $this->section('content')?>
 
-  <? if(!isset($nofooter)): ?>
+  <?php if(!isset($nofooter)): ?>
   <footer class="footer">
     <div class="row">
       <div class="col-md-3">
@@ -71,7 +71,7 @@
       </div>
     </div>
   </footer>
-  <? endif ?>
+  <?php endif ?>
 
 </body>
 </html>


### PR DESCRIPTION
For whatever reason the work in #43 wouldn't interpret `<?` tags, but would interpret full `<?php` tags, as well as short-hand output tags `<?=`

This PR rather than troubleshoot that setup converted non-output short-tags to full tags.