### PR TITLE
set grant_type=authorization_code in authz code request

### DIFF
--- a/app/Provider/IndieAuth.php
+++ b/app/Provider/IndieAuth.php
@@ -60,6 +60,7 @@ trait IndieAuth {
     }
 
     $params = [
+      'grant_type' => 'authorization_code',
       'code' => $query['code'],
       'client_id' => getenv('BASE_URL'),
       'redirect_uri' => getenv('BASE_URL').'redirect/indieauth',


### PR DESCRIPTION
In the latest 20201126 IndieAuth specification version, it has been
clarified that grant_type is a mandatory parameter that must be set
to authorization_code¹ when redeeming the authorization code at the
IndieAuth server. Set it accordingly.

¹ https://indieauth.spec.indieweb.org/#request

Fixes #69.