### PR TITLE
Improve mailto regex and ignore query params

### DIFF
--- a/app/Authenticate.php
+++ b/app/Authenticate.php
@@ -498,7 +498,7 @@ class Authenticate {
           'username' => $match[1],
           'display' => 'twitter.com/'.$match[1],
         ];
-      } elseif(preg_match('~^mailto:(.+)$~', $url, $match)) {
+      } elseif(preg_match('~^mailto:(.+\@.+?)(\?.*)?$~', $url, $match)) {
         $supported[] = [
           'provider' => 'email',
           'email' => $match[1],


### PR DESCRIPTION
First off, great project! Noticed an issue and attempted a fix here.

The following is a valid mailto link that prefills the subject line:

```
mailto:yousef@amar.io?Subject=Hello%2C%20Yousef!
```

Indielogin thinks this is my email:

```
yousef@amar.io?Subject=Hello%2C%20Yousef!
```

Which is not the case.

I therefore tweaked the regex such that:

| mailto link                                      | $match[1] before                          | $match[1] after |
|--------------------------------------------------|-------------------------------------------|-----------------|
| mailto:yousef@amar.io?Subject=Hello%2C%20Yousef! | yousef@amar.io?Subject=Hello%2C%20Yousef! | yousef@amar.io  |
| mailto:yousef@amar.io                            | yousef@amar.io                            | yousef@amar.io  |
| mailto:foo@bar                                   | foo@bar                                   | foo@bar         |
| mailto:foo@                                      | foo@                                      |                 |
| mailto:@bar                                      | @bar                                      |                 |
| mailto:foo                                       | foo                                       |                 |
| mailto:@                                         | @                                         |                 |
| mailto:                                          |                                           |                 |

You'll notice I also added a tiny bit that checks if it actually looks like an email also (\*@\*) but that's not strictly necessary. To remove that, we can just remove `\@.+` from the regex.