### PR TITLE
support client metadata as JSON URL

### DIFF
--- a/app/Controller.php
+++ b/app/Controller.php
@@ -14,6 +14,19 @@ class Controller {
     ]));
     return $response;
   }
+  
+  public function client_metadata(ServerRequestInterface $request, ResponseInterface $response) {
+    $response->getBody()->write(json_encode([
+      'client_id' => getenv('BASE_URL').'id',
+      'client_name' => getenv('APP_NAME'),
+      'client_uri' => getenv('BASE_URL'),
+      'logo_uri' => getenv('BASE_URL').'icons/apple-touch-icon.png',
+      'redirect_uris' => [
+        getenv('BASE_URL').'redirect/indieauth',
+      ],
+    ]));
+    return $response->withHeader('Content-type', 'application/json');
+  }
 
   public function demo(ServerRequestInterface $request, ResponseInterface $response) {
     $params = $request->getQueryParams();

--- a/app/Provider/IndieAuth.php
+++ b/app/Provider/IndieAuth.php
@@ -6,7 +6,7 @@ use Psr\Http\Message\ServerRequestInterface;
 use Config;
 
 trait IndieAuth {
-
+  
   private function _start_indieauth(&$response, $login_request, $details) {
     $userlog = make_logger('user');
 
@@ -16,7 +16,7 @@ trait IndieAuth {
     $authorize = \IndieAuth\Client::buildAuthorizationURL($details['authorization_endpoint'], [
       'me' => $login_request['me'],
       'redirect_uri' => getenv('BASE_URL').'redirect/indieauth',
-      'client_id' => getenv('BASE_URL'),
+      'client_id' => getenv('BASE_URL').'id',
       'state' => $state,
       'code_verifier' => $code_verifier,
     ]);
@@ -62,7 +62,7 @@ trait IndieAuth {
     $params = [
       'grant_type' => 'authorization_code',
       'code' => $query['code'],
-      'client_id' => getenv('BASE_URL'),
+      'client_id' => getenv('BASE_URL').'id',
       'redirect_uri' => getenv('BASE_URL').'redirect/indieauth',
       'code_verifier' => $_SESSION['code_verifier'],
     ];

--- a/public/index.php
+++ b/public/index.php
@@ -32,6 +32,8 @@ $route->map('GET', '/select', 'App\\Authenticate::select');
 $route->map('POST', '/auth', 'App\\Authenticate::verify')->setStrategy(new App\CORSStrategy);
 $route->map('POST', '/select', 'App\\Authenticate::post_select');
 
+$route->map('GET', '/id', 'App\\Controller::client_metadata');
+
 $route->map('GET', '/redirect/github', 'App\\Authenticate::redirect_github');
 $route->map('GET', '/redirect/twitter', 'App\\Authenticate::redirect_twitter');
 $route->map('GET', '/redirect/indieauth', 'App\\Authenticate::redirect_indieauth');


### PR DESCRIPTION
This implements what is needed to use a JSON URL as a `client_id` according to this proposal: https://github.com/indieweb/indieauth/issues/133